### PR TITLE
Adding a command for removal of tuupola/slim-jwt-auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ is the same.
 
 ```bash
 composer require -W jimtools/jwt-auth
+composer remove tuupola/slim-jwt-auth
 ```
 
 Update the `JwtAuthentication` config to have keys for the `secret` and


### PR DESCRIPTION
tuupola/slim-jwt-auth is not removed automatically from composer.json so it can be helpful to add a command