### PR TITLE
config array description should allow `logger` key

### DIFF
--- a/src/JwtAuthentication.php
+++ b/src/JwtAuthentication.php
@@ -92,6 +92,7 @@ final class JwtAuthentication implements MiddlewareInterface
      *   before: null|callable,
      *   after: null|callable,
      *   error: null|callable,
+     *   logger: null|LoggerInterface,
      * }
      */
     private array $options = [
@@ -106,7 +107,8 @@ final class JwtAuthentication implements MiddlewareInterface
         "ignore" => [],
         "before" => null,
         "after" => null,
-        "error" => null
+        "error" => null,
+        "logger" => null,
     ];
 
     /**
@@ -124,6 +126,7 @@ final class JwtAuthentication implements MiddlewareInterface
      *   before?: null|callable,
      *   after?: null|callable,
      *   error?: null|callable,
+     *   logger?: null|LoggerInterface,
      * } $options
      */
     public function __construct(array $options = [])


### PR DESCRIPTION
... since `logger()` is private the only way to set a logger is via constructor, but the array description (enforced by PHPStan) does not allow it yet.