### PR TITLE
fix PHP 8.4 deprecation error (implicitly nullable parameter)

### DIFF
--- a/src/JwtAuthentication.php
+++ b/src/JwtAuthentication.php
@@ -442,7 +442,7 @@ final class JwtAuthentication implements MiddlewareInterface
     /**
      * Set the logger.
      */
-    private function logger(LoggerInterface $logger = null): void
+    private function logger(?LoggerInterface $logger = null): void
     {
         $this->logger = $logger;
     }


### PR DESCRIPTION
Hope you don't mind another 1.x release ;-)